### PR TITLE
Register N3Parser for parsing Trig and N-Quads

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function mixin (object) {
   object.serializers = object.serializers || new rdf.Serializers()
 
   register(object.parsers, 'application/ld+json', new JsonLdParser({factory: rdf}))
+  register(object.parsers, 'application/trig', new N3Parser({factory: rdf}))
+  register(object.parsers, 'application/n-quads', new N3Parser({factory: rdf}))
   register(object.parsers, 'application/n-triples', new N3Parser({factory: rdf}))
   register(object.parsers, 'text/n3', new N3Parser({factory: rdf}))
   register(object.parsers, 'text/turtle', new N3Parser({factory: rdf}))

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,8 @@ describe('rdf-formats-common', () => {
       let mimeTypes = formats.parsers.list()
 
       assert.notEqual(mimeTypes.indexOf('application/ld+json'), -1)
+      assert.notEqual(mimeTypes.indexOf('application/trig'), -1)
+      assert.notEqual(mimeTypes.indexOf('application/n-quads'), -1)
       assert.notEqual(mimeTypes.indexOf('application/n-triples'), -1)
       assert.notEqual(mimeTypes.indexOf('text/n3'), -1)
       assert.notEqual(mimeTypes.indexOf('text/turtle'), -1)
@@ -28,6 +30,8 @@ describe('rdf-formats-common', () => {
 
     it('.find should find parsers for standard formats', () => {
       assert(formats.parsers.find('application/ld+json') instanceof JsonLdParser)
+      assert(formats.parsers.find('application/trig') instanceof N3Parser)
+      assert(formats.parsers.find('application/n-quads') instanceof N3Parser)
       assert(formats.parsers.find('application/n-triples') instanceof N3Parser)
       assert(formats.parsers.find('text/n3') instanceof N3Parser)
       assert(formats.parsers.find('text/turtle') instanceof N3Parser)


### PR DESCRIPTION
This depends on https://github.com/rdf-ext/rdf-parser-n3/pull/8.